### PR TITLE
"Fix" controller tests

### DIFF
--- a/test/controllers/databases_controller_test.rb
+++ b/test/controllers/databases_controller_test.rb
@@ -47,7 +47,7 @@ class DatabasesControllerTest < ActionController::TestCase
 
   test "should create database" do
     assert_difference('Database.count') do
-      post :create, database: {description: @database.description, name: @database.name}
+      post :create, params: { database: { description: @database.description, name: @database.name } }
     end
 
     assert_redirected_to database_path(assigns(:database))
@@ -55,7 +55,7 @@ class DatabasesControllerTest < ActionController::TestCase
 
   # Hint: collection_check_boxes
   test 'the form shows collection_check_boxes for Hosts' do
-    get :edit, id: @database
+    get :edit, params: { id: @database }
     assert_select '.field' do
       assert_select 'label[for="database_host_ids"]', "Hosts"
       assert_select 'input[name="database[host_ids][]"]'
@@ -64,7 +64,7 @@ class DatabasesControllerTest < ActionController::TestCase
 
   # Hint: collection_check_boxes
   test 'the form shows collection_check_boxes for Users' do
-    get :edit, id: @database
+    get :edit, params: { id: @database }
     assert_select '.field' do
       assert_select 'label[for="database_user_ids"]', "Give access to users"
       assert_select 'input[name="database[user_ids][]"]'
@@ -72,23 +72,23 @@ class DatabasesControllerTest < ActionController::TestCase
   end
 
   test "should show database" do
-    get :show, id: @database
+    get :show, params: { id: @database }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @database
+    get :edit, params: { id: @database }
     assert_response :success
     assert_select 'form.ui.form'
   end
 
   test "should update database" do
-    patch :update, id: @database, database: {description: @database.description, name: @database.name}
+    patch :update, params: { id: @database, database: {description: @database.description, name: @database.name} }
     assert_redirected_to database_path(assigns(:database))
   end
 
   test "Should update database with users and hosts" do
-    patch :update, id: @database, database: {description: @database.description, name: @database.name, host_ids: [hosts(:one).id], user_ids: [users(:one).id]}
+    patch :update, params: { id: @database, database: {description: @database.description, name: @database.name, host_ids: [hosts(:one).id], user_ids: [users(:one).id]} }
     assert_redirected_to database_path(assigns(:database))
     assert_equal [hosts(:one).id], assigns(:database).host_ids
     assert_equal [users(:one).id], assigns(:database).user_ids
@@ -96,21 +96,21 @@ class DatabasesControllerTest < ActionController::TestCase
 
   test "should destroy database" do
     assert_difference('Database.count', -1) do
-      delete :destroy, id: @database
+      delete :destroy, params: { id: @database }
     end
 
     assert_redirected_to databases_path
   end
 
   test "shouldn't update database without a name" do
-    patch :update, id: @database, database: {name: nil}
+    patch :update, params: { id: @database, database: {name: nil} }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this database from being saved:"
     assert_select "li", "Name can't be blank"
   end
 
   test "shouldn't create without name" do
-    post :create, database: {name: nil}
+    post :create, params: { database: { name: nil } }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this database from being saved:"
     assert_select "li", "Name can't be blank"

--- a/test/controllers/environments_controller_test.rb
+++ b/test/controllers/environments_controller_test.rb
@@ -19,44 +19,44 @@ class EnvironmentsControllerTest < ActionController::TestCase
 
   test "should create environment" do
     assert_difference('Environment.count') do
-      post :create, environment: {name: @environment.name}
+      post :create, params: { environment: {name: @environment.name} }
     end
 
     assert_redirected_to environment_path(assigns(:environment))
   end
 
   test "should show environment" do
-    get :show, id: @environment
+    get :show, params: { id: @environment }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @environment
+    get :edit, params: { id: @environment }
     assert_response :success
   end
 
   test "should update environment" do
-    patch :update, id: @environment, environment: {name: @environment.name}
+    patch :update, params: { id: @environment, environment: {name: @environment.name} }
     assert_redirected_to environment_path(assigns(:environment))
   end
 
   test "should destroy environment" do
     assert_difference('Environment.count', -1) do
-      delete :destroy, id: @environment
+      delete :destroy, params: { id: @environment }
     end
 
     assert_redirected_to environments_path
   end
 
   test "shouldn't update environment without a name" do
-    patch :update, id: @environment, environment: {name: nil}
+    patch :update, params: { id: @environment, environment: {name: nil} }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this environment from being saved:"
     assert_select "li", "Name can't be blank"
   end
 
   test "shouldn't create without name" do
-    post :create, environment: {name: nil}
+    post :create, params: { environment: {name: nil} }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this environment from being saved:"
     assert_select "li", "Name can't be blank"

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -24,30 +24,30 @@ class HostsControllerTest < ActionController::TestCase
 
   test "should create host" do
     assert_difference('Host.count') do
-      post :create, host: {environment_id: @host.environment_id, hostname: @host.hostname+'1', ip: @host.ip.next, operating_system: @host.operating_system}
+      post :create, params: { host: {environment_id: @host.environment_id, hostname: @host.hostname+'1', ip: @host.ip.next, operating_system: @host.operating_system} }
     end
 
     assert_redirected_to host_path(assigns(:host))
   end
 
   test "should show host" do
-    get :show, id: @host
+    get :show, params: { id: @host }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @host
+    get :edit, params: { id: @host }
     assert_response :success
   end
 
   test "should update host" do
-    patch :update, id: @host, host: {environment_id: @host.environment_id, hostname: @host.hostname+'1', ip: @host.ip.next, operating_system: @host.operating_system}
+    patch :update, params: { id: @host, host: {environment_id: @host.environment_id, hostname: @host.hostname+'1', ip: @host.ip.next, operating_system: @host.operating_system} }
     assert_redirected_to host_path(assigns(:host))
   end
 
   test "should destroy host" do
     assert_difference('Host.count', -1) do
-      delete :destroy, id: @host
+      delete :destroy, params: { id: @host }
     end
 
     assert_redirected_to hosts_path
@@ -56,14 +56,14 @@ class HostsControllerTest < ActionController::TestCase
   # Hier ist der reguläre Ausdruck für die Validierung der IP-Adresse
   #     \A(?:[0-9]{1,3}\.){3}[0-9]{1,3}\z
   test "shouldn't update host with an invalid IP" do
-    patch :update, id: @host, host: {ip: "invalid", hostname: '2'}
+    patch :update, params: { id: @host, host: { ip: "invalid", hostname: '2' } }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this host from being saved:"
     assert_select "li", "Ip is invalid"
   end
 
   test "shouldn't create with an invalid IP" do
-    post :create, host: {name: nil}
+    post :create, params: { host: { name: nil } }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this host from being saved:"
     assert_select "li", "Ip is invalid"

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -20,45 +20,45 @@ class UsersControllerTest < ActionController::TestCase
   # Hint: attr_accessor :password
   test "should create user" do
     assert_difference('User.count') do
-      post :create, user: {email: @user.email, password: @user.password, username: @user.username}
+      post :create, params: { user: { email: @user.email, password: @user.password, username: @user.username } }
     end
 
     assert_redirected_to user_path(assigns(:user))
   end
 
   test "should show user" do
-    get :show, id: @user
+    get :show, params: { id: @user }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @user
+    get :edit, params: { id: @user }
     assert_response :success
   end
 
   # Hint: attr_accessor :password
   test "should update user" do
-    patch :update, id: @user, user: {email: @user.email, password: @user.password, username: @user.username}
+    patch :update, params: { id: @user, user: { email: @user.email, password: @user.password, username: @user.username } }
     assert_redirected_to user_path(assigns(:user))
   end
 
   test "should destroy user" do
     assert_difference('User.count', -1) do
-      delete :destroy, id: @user
+      delete :destroy, params: { id: @user }
     end
 
     assert_redirected_to users_path
   end
 
   test "shouldn't update user without a email" do
-    patch :update, id: @user, user: {email: "", username: @user.username}
+    patch :update, params: { id: @user, user: {email: "", username: @user.username} }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this user from being saved:"
     assert_select "li", "Email can't be blank"
   end
 
   test "shouldn't create without email" do
-    post :create, user: {email: nil, username: @user.username}
+    post :create, params: { user: {email: nil, username: @user.username} }
     assert_response :success
     assert_select "#error_explanation > h2", "1 error prohibited this user from being saved:"
     assert_select "li", "Email can't be blank"


### PR DESCRIPTION
It seems like they're compatible with Rails 6 after this change.
Grade calculation seems to be broken, though:
```
Finished in 3.745231s, 12.8163 runs/s, 28.3027 assertions/s.
48 runs, 106 assertions, 1 failures, 0 errors, 0 skips
==================================
 Klausurergebnis: 42.13%
==================================
```